### PR TITLE
add pypi publish workflow

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,0 +1,29 @@
+name: PYPI Publish
+
+on:
+  release:
+    types: [published, edited]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        cd PythonAPI
+        python setup.py sdist
+        twine upload dist/*

--- a/PythonAPI/MANIFEST.in
+++ b/PythonAPI/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include common *.cpp *.c *.h
+recursive-include pycocotools *.py *.c *.pyx


### PR DESCRIPTION
Fixed missing package files issue in #2 by adding a MANIFEST.in file.

Now can be installed by pip without any issue. You can check it by pip install [pycocotools-fix-test](https://pypi.org/project/pycocotools-fix-test/).

Files in tar.gz are same for [pycocotools-fix](https://pypi.org/project/pycocotools-fix/#files) and [pycocotools-fix-test](https://pypi.org/project/pycocotools-fix-test/#files).